### PR TITLE
[issue #25] add support for provider states with parameters

### DIFF
--- a/consumer/ftest-incontainer/src/test/java/ClientGatewayTest.java
+++ b/consumer/ftest-incontainer/src/test/java/ClientGatewayTest.java
@@ -32,8 +32,11 @@ public class ClientGatewayTest {
         Map<String, String> header = new HashMap<>();
         header.put("Content-Type", "application/json");
 
+        Map<String, Object> stateParams = new HashMap<>();
+        stateParams.put("name", "Alexandra");
+
         return builder
-                .given("test state")
+                .given("test state", stateParams)
                 .uponReceiving("ConsumerTest test interaction")
                 .path("/")
                 .method("GET")

--- a/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
+++ b/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
@@ -131,7 +131,7 @@ public class InteractionRunner {
     protected void validateState(final TestClass testClass, final List<Throwable> errors) {
         Arrays.stream(testClass.getMethods(State.class)).forEach(method -> {
             validatePublicVoidMethods(method, errors);
-            if (method.getParameterCount() == 1 && !Map.class.isAssignableFrom(method.getParameterTypes()[0])) {
+            if (isMethodWithSingleMapParameter(method)) {
                 final String mapError = String.format("Method %s should take only a single Map parameter", method.getName());
                 logger.log(Level.SEVERE, mapError);
                 errors.add(new IllegalArgumentException(mapError));
@@ -141,6 +141,10 @@ public class InteractionRunner {
                 errors.add(new IllegalArgumentException(multipleParametersError));
             }
         });
+    }
+
+    private boolean isMethodWithSingleMapParameter(Method method) {
+        return method.getParameterCount() == 1 && !Map.class.isAssignableFrom(method.getParameterTypes()[0]);
     }
 
     protected void validateTargetRequestFilters(final TestClass testClass, final List<Throwable> errors) {
@@ -235,9 +239,7 @@ public class InteractionRunner {
     private void executeMethod(Method method, Object target, Object... params) {
         try {
             method.invoke(target, params);
-        } catch (IllegalAccessException e) {
-            throw new IllegalArgumentException(e);
-        } catch (InvocationTargetException e) {
+        } catch (IllegalAccessException | InvocationTargetException e) {
             throw new IllegalArgumentException(e);
         }
     }

--- a/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
+++ b/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
@@ -2,6 +2,7 @@ package org.arquillian.pact.provider.core;
 
 import au.com.dius.pact.model.Consumer;
 import au.com.dius.pact.model.Pact;
+import au.com.dius.pact.model.ProviderState;
 import au.com.dius.pact.model.RequestResponseInteraction;
 import au.com.dius.pact.model.RequestResponsePact;
 import org.apache.commons.lang3.ArrayUtils;
@@ -30,7 +31,9 @@ import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -53,7 +56,7 @@ public class InteractionRunner {
         TestClass testClass = test.getEvent().getTestClass();
 
         final List<Throwable> errors = new ArrayList<>();
-        validatePublicVoidNoArgMethods(testClass, State.class, errors);
+        validateState(testClass, errors);
         validateTargetRequestFilters(testClass, errors);
         validateTestTarget(testClass, errors);
 
@@ -125,6 +128,21 @@ public class InteractionRunner {
         }
     }
 
+    protected void validateState(final TestClass testClass, final List<Throwable> errors) {
+        Arrays.stream(testClass.getMethods(State.class)).forEach(method -> {
+            validatePublicVoidMethods(method, errors);
+            if (method.getParameterCount() == 1 && !Map.class.isAssignableFrom(method.getParameterTypes()[0])) {
+                final String mapError = String.format("Method %s should take only a single Map parameter", method.getName());
+                logger.log(Level.SEVERE, mapError);
+                errors.add(new IllegalArgumentException(mapError));
+            } else if (method.getParameterCount() > 1) {
+                final String multipleParametersError = String.format("Method %s should either take no parameters or a single Map parameter", method.getName());
+                logger.log(Level.SEVERE, multipleParametersError);
+                errors.add(new IllegalArgumentException(multipleParametersError));
+            }
+        });
+    }
+
     protected void validateTargetRequestFilters(final TestClass testClass, final List<Throwable> errors) {
         Method[] methods = testClass.getMethods(TargetRequestFilter.class);
         for (Method method : methods) {
@@ -162,18 +180,16 @@ public class InteractionRunner {
         }
     }
 
-    protected void validatePublicVoidNoArgMethods(final TestClass testClass, final Class<? extends Annotation> annotation, final List<Throwable> errors) {
-        Method[] methods = testClass.getMethods(annotation);
-        for (Method method : methods) {
-            if (!isPublic(method)) {
-                String publicError = String.format("Method %s annotated with %s should be public.", method.getName(), annotation.getName());
-                logger.log(Level.SEVERE, publicError);
-                errors.add(new IllegalArgumentException(publicError));
-            }
-            if (method.getParameterCount() != 0) {
-                String parametersError = String.format("Method %s annotated with %s should contain no parameters", method.getName(), annotation.getName());
-                logger.log(Level.SEVERE, parametersError);
-            }
+    protected void validatePublicVoidMethods(Method method, final List<Throwable> errors) {
+        if (!isPublic(method)) {
+            String publicError = String.format("Method %s should be public.", method.getName());
+            logger.log(Level.SEVERE, publicError);
+            errors.add(new IllegalArgumentException(publicError));
+        }
+        if (!returnsVoid(method)) {
+            String voidError = String.format("Method %s should return void");
+            logger.log(Level.SEVERE, voidError);
+            errors.add(new IllegalArgumentException(voidError));
         }
     }
 
@@ -201,23 +217,30 @@ public class InteractionRunner {
     }
 
     protected void executeStateChanges(final RequestResponseInteraction interaction, final TestClass testClass, final Object target) {
-        if (interaction.getProviderState() != null && !interaction.getProviderState().isEmpty()) {
-            final String state = interaction.getProviderState();
-            for (Method ann : testClass.getMethods(State.class)) {
-                if (ArrayUtils.contains(ann.getAnnotation(State.class).value(), state)) {
-                    try {
-                        ann.invoke(target);
-                    } catch (IllegalAccessException e) {
-                        throw new IllegalArgumentException(e);
-                    } catch (InvocationTargetException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                }
+        if (!interaction.getProviderStates().isEmpty()) {
+            for (final ProviderState state : interaction.getProviderStates()) {
+                Arrays.stream(testClass.getMethods(State.class))
+                        .filter(method -> ArrayUtils.contains(method.getAnnotation(State.class).value(), state.getName()))
+                        .forEach(method -> {
+                            if (method.getParameterCount() == 1) {
+                                executeMethod(method, target, state.getParams());
+                            } else {
+                                executeMethod(method, target);
+                            }
+                        });
             }
-
         }
     }
 
+    private void executeMethod(Method method, Object target, Object... params) {
+        try {
+            method.invoke(target, params);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 
     private List<Field> getFieldsWithAnnotation(final Class<?> source,
                                                 final Class<? extends Annotation> annotationClass) {
@@ -245,5 +268,9 @@ public class InteractionRunner {
 
     private boolean isPublic(Method method) {
         return Modifier.isPublic(method.getModifiers());
+    }
+
+    private boolean returnsVoid(Method method) {
+        return Void.TYPE.equals(method.getReturnType());
     }
 }

--- a/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
+++ b/provider/core/src/main/java/org/arquillian/pact/provider/core/InteractionRunner.java
@@ -131,7 +131,7 @@ public class InteractionRunner {
     protected void validateState(final TestClass testClass, final List<Throwable> errors) {
         Arrays.stream(testClass.getMethods(State.class)).forEach(method -> {
             validatePublicVoidMethods(method, errors);
-            if (isMethodWithSingleMapParameter(method)) {
+            if (methodDoesNotHaveSingleMapParameter(method)) {
                 final String mapError = String.format("Method %s should take only a single Map parameter", method.getName());
                 logger.log(Level.SEVERE, mapError);
                 errors.add(new IllegalArgumentException(mapError));
@@ -143,7 +143,7 @@ public class InteractionRunner {
         });
     }
 
-    private boolean isMethodWithSingleMapParameter(Method method) {
+    private boolean methodDoesNotHaveSingleMapParameter(Method method) {
         return method.getParameterCount() == 1 && !Map.class.isAssignableFrom(method.getParameterTypes()[0]);
     }
 

--- a/provider/core/src/test/java/org/arquillian/pact/provider/core/InteractionRunnerTest.java
+++ b/provider/core/src/test/java/org/arquillian/pact/provider/core/InteractionRunnerTest.java
@@ -24,6 +24,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
@@ -79,12 +80,9 @@ public class InteractionRunnerTest {
         interactionRunner.pactsInstance = pactsInstance;
         interactionRunner.targetInstance = () -> target;
 
-        try {
-            interactionRunner.executePacts(eventContext);
-            fail("Exception should be thrown");
-        } catch(IllegalArgumentException e) {
-            assertThat(e).hasMessage("Field annotated with org.jboss.arquillian.test.api.ArquillianResource should implement org.arquillian.pact.provider.core.httptarget.Target and didn't found any");
-        }
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> interactionRunner.executePacts(eventContext))
+                .withMessage("Field annotated with org.jboss.arquillian.test.api.ArquillianResource should implement org.arquillian.pact.provider.core.httptarget.Target and didn't found any");
 
     }
 
@@ -94,17 +92,13 @@ public class InteractionRunnerTest {
         PactProviderWithWrongStateMethod pactDefinition = new PactProviderWithWrongStateMethod();
         when(test.getTestInstance()).thenReturn(pactDefinition);
 
-        InteractionRunner interactionRunner = new InteractionRunner();
+        final InteractionRunner interactionRunner = new InteractionRunner();
         interactionRunner.pactsInstance = pactsInstance;
         interactionRunner.targetInstance = () -> target;
 
-        try {
-            interactionRunner.executePacts(eventContext);
-            fail("Exception should be thrown");
-        } catch(IllegalArgumentException e) {
-            assertThat(e).hasMessage("Method stateMethod should take only a single Map parameter");
-        }
-
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> interactionRunner.executePacts(eventContext))
+                .withMessage("Method stateMethod should take only a single Map parameter");
     }
 
     @Provider("planets_provider")

--- a/provider/core/src/test/java/org/arquillian/pact/provider/core/InteractionRunnerTest.java
+++ b/provider/core/src/test/java/org/arquillian/pact/provider/core/InteractionRunnerTest.java
@@ -9,6 +9,7 @@ import org.arquillian.pact.provider.core.httptarget.Target;
 import org.arquillian.pact.provider.spi.CurrentConsumer;
 import org.arquillian.pact.provider.spi.CurrentInteraction;
 import org.arquillian.pact.provider.spi.Provider;
+import org.arquillian.pact.provider.spi.State;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.spi.EventContext;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -87,6 +88,25 @@ public class InteractionRunnerTest {
 
     }
 
+    @org.junit.Test
+    public void should_throw_exception_when_state_param_is_not_empy_nor_map() {
+        when(test.getTestClass()).thenReturn(new TestClass(PactProviderWithWrongStateMethod.class));
+        PactProviderWithWrongStateMethod pactDefinition = new PactProviderWithWrongStateMethod();
+        when(test.getTestInstance()).thenReturn(pactDefinition);
+
+        InteractionRunner interactionRunner = new InteractionRunner();
+        interactionRunner.pactsInstance = pactsInstance;
+        interactionRunner.targetInstance = () -> target;
+
+        try {
+            interactionRunner.executePacts(eventContext);
+            fail("Exception should be thrown");
+        } catch(IllegalArgumentException e) {
+            assertThat(e).hasMessage("Method stateMethod should take only a single Map parameter");
+        }
+
+    }
+
     @Provider("planets_provider")
     @PactFolder("pacts")
     public static class PactProviderWithNoTarget {
@@ -113,4 +133,25 @@ public class InteractionRunnerTest {
         Target target;
 
     }
+
+    @Provider("planets_provider")
+    @PactFolder("pacts")
+    public static class PactProviderWithWrongStateMethod {
+
+        @State("default")
+        public void stateMethod(String param) {
+
+        }
+
+        @CurrentConsumer
+        Consumer consumer;
+
+        @CurrentInteraction
+        RequestResponseInteraction interaction;
+
+        @ArquillianResource
+        Target target;
+
+    }
+
 }

--- a/provider/ftest-incontainer/pom.xml
+++ b/provider/ftest-incontainer/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/provider/ftest-incontainer/pom.xml
+++ b/provider/ftest-incontainer/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/provider/ftest-incontainer/src/test/java/org/arquillian/pact/provider/ftest/MyServiceProviderTest.java
+++ b/provider/ftest-incontainer/src/test/java/org/arquillian/pact/provider/ftest/MyServiceProviderTest.java
@@ -3,6 +3,8 @@ package org.arquillian.pact.provider.ftest;
 import org.arquillian.pact.provider.core.httptarget.Target;
 import org.arquillian.pact.provider.core.loader.PactFolder;
 import org.arquillian.pact.provider.spi.Provider;
+import org.arquillian.pact.provider.spi.State;
+import org.assertj.core.api.Assertions;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -12,6 +14,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.net.URL;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Arquillian.class)
 @Provider("test_provider")
@@ -28,6 +33,11 @@ public class MyServiceProviderTest {
 
     @ArquillianResource
     Target target;
+
+    @State("test state")
+    public void testStateMethod(Map<String, Object> params) {
+        assertThat(params).containsEntry("name", "Alexandra");
+    }
 
     @Test
     public void should_provide_valid_answers() {

--- a/provider/ftest-incontainer/src/test/resources/pacts/test_consumer-test_provider.json
+++ b/provider/ftest-incontainer/src/test/resources/pacts/test_consumer-test_provider.json
@@ -22,12 +22,19 @@
                     "responsetest": true
                 }
             },
-            "providerState": "test state"
+            "providerStates": [
+                {
+                    "name": "test state",
+                    "params": {
+                        "name": "Alexandra"
+                    }
+                }
+            ]
         }
     ],
     "metadata": {
         "pact-specification": {
-            "version": "2.0.0"
+            "version": "3.0.0"
         },
         "pact-jvm": {
             "version": ""


### PR DESCRIPTION
Implements provider states with parameters introduced at Version 3 of Pact Spec https://github.com/pact-foundation/pact-specification/tree/version-3#allow-multiple-provider-states-with-parameters Currently in Arquillian Pact we only support the version 2 of provider states where the parameter was just a descriptive string.

States in Pact is a way of communicating from consumer part, which is the state we expect to provider side before executing the contracts tests. For example that a user must exists.