### PR TITLE
Add default value to key in PactGit

### DIFF
--- a/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGit.java
+++ b/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGit.java
@@ -46,7 +46,7 @@ public @interface PactGit {
      * Location and name of the private key. By default ~/.ssh/id_rsa
      * @return
      */
-    String key() default "";
+    String key() default "~/.ssh/id_rsa";
 
     /**
      * Directory where remote git repository is cloned. By default uses temp directory

--- a/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGitLoader.java
+++ b/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGitLoader.java
@@ -185,7 +185,7 @@ public class PactGitLoader implements PactLoader {
 
     private Path getPrivateKey() {
         if (isSet(this.pactGit.key())) {
-            return Paths.get(getResolvedValue(this.pactGit.key()));
+            return Paths.get(getResolvedValue(resolveHomeDirectory(this.pactGit.key())));
         }
 
         return null;
@@ -197,5 +197,12 @@ public class PactGitLoader implements PactLoader {
 
     private String getResolvedValue(String field) {
         return PactRunnerExpressionParser.parseExpressions(field);
+    }
+
+    public static String resolveHomeDirectory(String path) {
+        if(path.startsWith("~")) {
+            return path.replace("~", System.getProperty("user.home"));
+        }
+        return path;
     }
 }


### PR DESCRIPTION
After this commit, key property in PactGit will provide a default value
"~/.ssh/id_rsa" and the home directory will be resolved.

See gh-30