### PR TITLE
Fix username and password validation in PactGitLoader

### DIFF
--- a/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGitLoader.java
+++ b/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGitLoader.java
@@ -158,7 +158,7 @@ public class PactGitLoader implements PactLoader {
 
     private PullResult executePull(Git git) {
         final PullResult pullResult;
-        if (isSet(this.pactGit.username()) && isSet(this.pactGit.passphrase())) {
+        if (isSet(this.pactGit.username()) && isSet(this.pactGit.password())) {
 
             pullResult = this.gitOperations.pullRepository(git,
                     getResolvedValue(this.pactGit.remote()),


### PR DESCRIPTION
This commit fix the validation when username and password are provided.

See gh-31