### PR TITLE
[issue #19] Enable @Pact annotation at class level

### DIFF
--- a/consumer/core/pom.xml
+++ b/consumer/core/pom.xml
@@ -96,6 +96,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-impl-base</artifactId>
             <classifier>tests</classifier>

--- a/consumer/core/src/main/java/org/arquillian/pact/consumer/core/AbstractConsumerPactTest.java
+++ b/consumer/core/src/main/java/org/arquillian/pact/consumer/core/AbstractConsumerPactTest.java
@@ -10,6 +10,7 @@ import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.model.MockProviderConfig;
 import au.com.dius.pact.model.PactFragment;
 import org.arquillian.pact.consumer.core.client.container.ConsumerProviderPair;
+import org.arquillian.pact.consumer.core.util.ResolveClassAnnotation;
 import org.arquillian.pact.consumer.spi.Pact;
 import org.arquillian.pact.consumer.spi.PactVerification;
 import org.jboss.arquillian.core.api.Instance;
@@ -19,11 +20,17 @@ import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.arquillian.test.spi.event.suite.Test;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 
 public abstract class AbstractConsumerPactTest {
 
+    private static final Logger logger = Logger.getLogger(AbstractConsumerPactTest.class.getName());
     private static final VerificationResult PACT_VERIFIED = PactVerified$.MODULE$;
 
     @Inject
@@ -99,12 +106,13 @@ public abstract class AbstractConsumerPactTest {
         }
     }
 
-    private Optional<Method> findPactMethod(String currentProvider, TestClass testClass, PactVerification pactVerification) {
+    protected Optional<Method> findPactMethod(String currentProvider, TestClass testClass, PactVerification pactVerification) {
         String pactFragment = pactVerification.fragment();
 
-        final Method[] pactMethods = testClass.getMethods(Pact.class);
+        final Optional<Class<?>> classWithPactAnnotation = ResolveClassAnnotation.getClassWithAnnotation(testClass.getJavaClass(), Pact.class);
+        final List<Method> pactMethods = findPactFragmentMethods(testClass);
         for (Method method : pactMethods) {
-            Pact pact = method.getAnnotation(Pact.class);
+            Pact pact = resolvePactAnnotation(classWithPactAnnotation, method);
             if (pact != null && pact.provider().equals(currentProvider)
                     && (pactFragment.isEmpty() || pactFragment.equals(method.getName()))) {
 
@@ -113,6 +121,27 @@ public abstract class AbstractConsumerPactTest {
             }
         }
         return Optional.empty();
+    }
+
+    private Pact resolvePactAnnotation(Optional<Class<?>> clazz, Method method) {
+        Pact pactMethodAnnotation = method.getAnnotation(Pact.class);
+
+        if (pactMethodAnnotation == null) {
+            // It can be at class level.
+            if (clazz.isPresent()) {
+                return clazz.get().getAnnotation(Pact.class);
+            } else {
+                // method will be ignored.
+                logger.log(Level.INFO, String.format("Method %s returns a %s type but it is not annotated at method nor at class level with %s",
+                        method.getName(),
+                        PactFragment.class.getName(),
+                        Pact.class.getName()));
+                return null;
+            }
+        } else {
+            return pactMethodAnnotation;
+        }
+
     }
 
     private void validatePactSignature(Method method) {
@@ -125,6 +154,14 @@ public abstract class AbstractConsumerPactTest {
             throw new UnsupportedOperationException("Method " + method.getName() +
                     " does not conform required method signature 'public PactFragment xxx(PactDslWithProvider builder)'");
         }
+    }
+
+    private List<Method> findPactFragmentMethods(TestClass testClass) {
+        final Method[] methods = testClass.getJavaClass().getMethods();
+
+        return Arrays.stream(methods)
+                .filter(method -> method.getReturnType().isAssignableFrom(PactFragment.class))
+                .collect(Collectors.toList());
     }
 
 }

--- a/consumer/core/src/main/java/org/arquillian/pact/consumer/core/AbstractConsumerPactTest.java
+++ b/consumer/core/src/main/java/org/arquillian/pact/consumer/core/AbstractConsumerPactTest.java
@@ -112,8 +112,8 @@ public abstract class AbstractConsumerPactTest {
         final Optional<Class<?>> classWithPactAnnotation = ResolveClassAnnotation.getClassWithAnnotation(testClass.getJavaClass(), Pact.class);
         final List<Method> pactMethods = findPactFragmentMethods(testClass);
         for (Method method : pactMethods) {
-            Pact pact = resolvePactAnnotation(classWithPactAnnotation, method);
-            if (pact != null && pact.provider().equals(currentProvider)
+            Optional<Pact> pact = resolvePactAnnotation(classWithPactAnnotation, method);
+            if (pact.isPresent() && pact.get().provider().equals(currentProvider)
                     && (pactFragment.isEmpty() || pactFragment.equals(method.getName()))) {
 
                 validatePactSignature(method);
@@ -123,13 +123,13 @@ public abstract class AbstractConsumerPactTest {
         return Optional.empty();
     }
 
-    private Pact resolvePactAnnotation(Optional<Class<?>> clazz, Method method) {
+    private Optional<Pact> resolvePactAnnotation(Optional<Class<?>> clazz, Method method) {
         Pact pactMethodAnnotation = method.getAnnotation(Pact.class);
 
         if (pactMethodAnnotation == null) {
             // It can be at class level.
             if (clazz.isPresent()) {
-                return clazz.get().getAnnotation(Pact.class);
+                return Optional.ofNullable(clazz.get().getAnnotation(Pact.class));
             } else {
                 // method will be ignored.
                 logger.log(Level.INFO, String.format("Method %s returns a %s type but it is not annotated at method nor at class level with %s",
@@ -139,7 +139,7 @@ public abstract class AbstractConsumerPactTest {
                 return null;
             }
         } else {
-            return pactMethodAnnotation;
+            return Optional.of(pactMethodAnnotation);
         }
 
     }

--- a/consumer/core/src/main/java/org/arquillian/pact/consumer/core/client/PactConsumerArchiveAppender.java
+++ b/consumer/core/src/main/java/org/arquillian/pact/consumer/core/client/PactConsumerArchiveAppender.java
@@ -8,6 +8,7 @@ import org.arquillian.pact.consumer.core.client.container.PactConsumerConfigurat
 import org.arquillian.pact.consumer.core.client.container.PactConsumerRemoteExtension;
 import org.arquillian.pact.consumer.core.client.container.RemoteConsumerPactTest;
 import org.arquillian.pact.consumer.core.util.PactConsumerVersionExtractor;
+import org.arquillian.pact.consumer.core.util.ResolveClassAnnotation;
 import org.arquillian.pact.consumer.spi.Pact;
 import org.jboss.arquillian.container.test.spi.RemoteLoadableExtension;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
@@ -35,7 +36,8 @@ public class PactConsumerArchiveAppender implements AuxiliaryArchiveAppender {
                 .addClasses(AbstractConsumerPactTest.class,
                         RemoteConsumerPactTest.class, PactConsumerConfiguration.class,
                         MockProviderConfigCreator.class, PactConsumerConfigurator.class,
-                        PactConsumerRemoteExtension.class, PactFilesCommand.class, ConsumerProviderPair.class)
+                        PactConsumerRemoteExtension.class, PactFilesCommand.class, ConsumerProviderPair.class,
+                        ResolveClassAnnotation.class)
                 .addPackages(true, Pact.class.getPackage())
                 .addAsServiceProvider(RemoteLoadableExtension.class, PactConsumerRemoteExtension.class);
 

--- a/consumer/core/src/main/java/org/arquillian/pact/consumer/core/util/ResolveClassAnnotation.java
+++ b/consumer/core/src/main/java/org/arquillian/pact/consumer/core/util/ResolveClassAnnotation.java
@@ -1,0 +1,31 @@
+package org.arquillian.pact.consumer.core.util;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+/**
+ * Class that returns if a class or any subclass is annotated with given annotation.
+ */
+public class ResolveClassAnnotation {
+
+    /**
+     * Class that returns if a class or any subclass is annotated with given annotation.
+     * @param source class.
+     * @param annotationClass to find.
+     * @return Class containing the annotation.
+     */
+    public static Optional<Class<?>> getClassWithAnnotation(final Class<?> source, final Class<? extends Annotation> annotationClass) {
+
+        Class<?> nextSource = source;
+        while (nextSource != Object.class) {
+            if(nextSource.isAnnotationPresent(annotationClass)) {
+                return Optional.of(nextSource);
+            } else {
+                nextSource = nextSource.getSuperclass();
+            }
+        }
+
+        return Optional.empty();
+    }
+
+}

--- a/consumer/core/src/test/java/org/arquillian/pact/consumer/core/ConsumerPactTestTest.java
+++ b/consumer/core/src/test/java/org/arquillian/pact/consumer/core/ConsumerPactTestTest.java
@@ -1,0 +1,101 @@
+package org.arquillian.pact.consumer.core;
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.model.PactFragment;
+import org.arquillian.pact.consumer.core.client.StandaloneConsumerPactTest;
+import org.arquillian.pact.consumer.spi.Pact;
+import org.arquillian.pact.consumer.spi.PactVerification;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ConsumerPactTestTest {
+
+    @Mock
+    PactVerification pactVerification;
+
+
+    @Before
+    public void setup() {
+        when(pactVerification.fragment()).thenReturn("");
+    }
+
+    @Test
+    public void should_get_pact_from_method() throws NoSuchMethodException {
+
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactMethod.class);
+        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p1", testClass, pactVerification);
+
+        assertThat(c).isPresent().contains(PactMethod.class.getMethod("contract1", PactDslWithProvider.class));
+
+    }
+
+    @Test
+    public void should_get_pact_from_class() throws NoSuchMethodException {
+
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactClass.class);
+        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p2", testClass, pactVerification);
+
+        assertThat(c).isPresent().contains(PactClass.class.getMethod("contract2", PactDslWithProvider.class));
+
+    }
+
+    @Test
+    public void should_give_preference_to_method_annotation() throws NoSuchMethodException {
+
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactMethodClass.class);
+        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p4", testClass, pactVerification);
+
+        assertThat(c).isPresent().contains(PactMethodClass.class.getMethod("contract3", PactDslWithProvider.class));
+
+    }
+
+    @Test
+    public void should_ignore_class_annotation_if_annotated_method() throws NoSuchMethodException {
+
+        AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
+        TestClass testClass = new TestClass(PactMethodClass.class);
+        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p3", testClass, pactVerification);
+
+        assertThat(c).isNotPresent();
+
+    }
+
+    public static class PactMethod {
+
+        @Pact(consumer = "c1", provider = "p1")
+        public PactFragment contract1(PactDslWithProvider builder) {
+            return null;
+        }
+
+    }
+
+    @Pact(consumer = "c2", provider = "p2")
+    public static class PactClass {
+        public PactFragment contract2(PactDslWithProvider builder) {
+            return null;
+        }
+    }
+
+    @Pact(consumer = "c3", provider = "p3")
+    public static class PactMethodClass {
+        @Pact(consumer = "c4", provider = "p4")
+        public PactFragment contract3(PactDslWithProvider builder) {
+            return null;
+        }
+    }
+
+}

--- a/consumer/core/src/test/java/org/arquillian/pact/consumer/core/ConsumerPactTestTest.java
+++ b/consumer/core/src/test/java/org/arquillian/pact/consumer/core/ConsumerPactTestTest.java
@@ -24,7 +24,6 @@ public class ConsumerPactTestTest {
     @Mock
     PactVerification pactVerification;
 
-
     @Before
     public void setup() {
         when(pactVerification.fragment()).thenReturn("");
@@ -35,9 +34,9 @@ public class ConsumerPactTestTest {
 
         AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
         TestClass testClass = new TestClass(PactMethod.class);
-        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p1", testClass, pactVerification);
+        final Optional<Method> pactFragmentMethod = abstractConsumerPactTest.findPactMethod("p1", testClass, pactVerification);
 
-        assertThat(c).isPresent().contains(PactMethod.class.getMethod("contract1", PactDslWithProvider.class));
+        assertThat(pactFragmentMethod).isPresent().contains(PactMethod.class.getMethod("contract1", PactDslWithProvider.class));
 
     }
 
@@ -46,9 +45,9 @@ public class ConsumerPactTestTest {
 
         AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
         TestClass testClass = new TestClass(PactClass.class);
-        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p2", testClass, pactVerification);
+        final Optional<Method> pactFragmentMethod = abstractConsumerPactTest.findPactMethod("p2", testClass, pactVerification);
 
-        assertThat(c).isPresent().contains(PactClass.class.getMethod("contract2", PactDslWithProvider.class));
+        assertThat(pactFragmentMethod).isPresent().contains(PactClass.class.getMethod("contract2", PactDslWithProvider.class));
 
     }
 
@@ -57,9 +56,9 @@ public class ConsumerPactTestTest {
 
         AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
         TestClass testClass = new TestClass(PactMethodClass.class);
-        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p4", testClass, pactVerification);
+        final Optional<Method> pactFragmentMethod = abstractConsumerPactTest.findPactMethod("p4", testClass, pactVerification);
 
-        assertThat(c).isPresent().contains(PactMethodClass.class.getMethod("contract3", PactDslWithProvider.class));
+        assertThat(pactFragmentMethod).isPresent().contains(PactMethodClass.class.getMethod("contract3", PactDslWithProvider.class));
 
     }
 
@@ -68,9 +67,9 @@ public class ConsumerPactTestTest {
 
         AbstractConsumerPactTest abstractConsumerPactTest = new StandaloneConsumerPactTest();
         TestClass testClass = new TestClass(PactMethodClass.class);
-        final Optional<Method> c = abstractConsumerPactTest.findPactMethod("p3", testClass, pactVerification);
+        final Optional<Method> pactFragmentMethod = abstractConsumerPactTest.findPactMethod("p3", testClass, pactVerification);
 
-        assertThat(c).isNotPresent();
+        assertThat(pactFragmentMethod).isNotPresent();
 
     }
 

--- a/consumer/core/src/test/java/org/arquillian/pact/consumer/core/util/ResolveClassAnnotationTest.java
+++ b/consumer/core/src/test/java/org/arquillian/pact/consumer/core/util/ResolveClassAnnotationTest.java
@@ -1,0 +1,28 @@
+package org.arquillian.pact.consumer.core.util;
+
+import org.arquillian.pact.consumer.spi.Pact;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResolveClassAnnotationTest {
+
+
+    @Test
+    public void should_get_annotation_from_class_level() {
+        assertThat(ResolveClassAnnotation.getClassWithAnnotation(A.class, Pact.class)).isPresent();
+    }
+
+    @Test
+    public void should_get_annotation_from_subclass() {
+        assertThat(ResolveClassAnnotation.getClassWithAnnotation(B.class, Pact.class)).isPresent();
+    }
+
+    @Pact(consumer = "c", provider = "p")
+    public static class A {
+    }
+
+    public static class B extends A {
+    }
+
+}

--- a/consumer/spi/src/main/java/org/arquillian/pact/consumer/spi/Pact.java
+++ b/consumer/spi/src/main/java/org/arquillian/pact/consumer/spi/Pact.java
@@ -13,7 +13,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Pact {
 
     /**


### PR DESCRIPTION
#### Short description of what this resolves:

Simplify set Consumer/Provider in consumer part. Currently we need to use @Pact annotation and set the consumer and the provider. The problem is that if you use pact fragments (and probably you are doing to maintain the unit of tests clear), you need to set these attributes over and over again. Change @Pact annotation to be able to set at class level.

#### Changes proposed in this pull request:

- `@Pact` can be set at (sub)class level
- It is not mandatory anymore annotate contract definition as `@Pact`

**Fixes**:  #19 

