### PR TITLE
Changes default value separator from :- to : to align with Arquillian

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -339,8 +339,8 @@ To configure folder publisher you need to configure `pactPublishConfiguration` w
 <1> `provider` attribute is used for setting which publisher to use. In case of Folder publisher, you need to set to `folder`.
 <2> `outputFolder` configures where to copy "pact" files.
 
-You can set `outputFolder` value using Java system property or environment variable by using form `${name:-defaultvalue}.
-For example `outputFolder: ${output:-/mypacts}` will first check if there is a Java system property with name output and get the value, if there is no value, then checks for environment variable.
+You can set `outputFolder` value using Java system property or environment variable by using form `${name:defaultvalue}.
+For example `outputFolder: ${output:/mypacts}` will first check if there is a Java system property with name output and get the value, if there is no value, then checks for environment variable.
 If that is not defined too it will use the default value i.e. `/mypacts`.
 
 ==== URL Publisher
@@ -369,7 +369,7 @@ For example given `http://myhost/pacts` and a "pact" file called `consumer_provi
 <1> `provider` attribute is used for setting which publisher to use. In case of URL publisher, you need to set to `url`.
 <2> `url` configures to send as `POST` the contract content.
 
-You can set `url` value using Java system property or environment variable by using form `${name:-defaultvalue}`.
+You can set `url` value using Java system property or environment variable by using form `${name:defaultvalue}`.
 
 ==== Git Publisher
 
@@ -410,7 +410,7 @@ First of all you need to add git publisher dependency:
             remote: origin # <7>
             repository: /git/myrepo # <8>
             pactDirectory: pacts/ # <9>
-            tag: v ${version:-1.0.0-SNAPSHOT} # <10>
+            tag: v ${version:1.0.0-SNAPSHOT} # <10>
             branch: master # <11>
             email: my@email.com # <12>
         </property>
@@ -431,7 +431,7 @@ First of all you need to add git publisher dependency:
 <11> `branch` sets a branch where contract files are copied and committed. By default is `master`.
 <12> `email` used for commit. By default it gets email from general configuration.
 
-Any of the git attributes can be set using Java system property or environment variable by using form `${name:-defaultvalue}`.
+Any of the git attributes can be set using Java system property or environment variable by using form `${name:defaultvalue}`.
 
 ==== SPI
 

--- a/common/configuration/src/main/java/org/arquillian/pact/configuration/SystemPropertyResolver.java
+++ b/common/configuration/src/main/java/org/arquillian/pact/configuration/SystemPropertyResolver.java
@@ -59,8 +59,8 @@ public class SystemPropertyResolver {
         }
 
         PropertyValueTuple invoke() {
-            if (propertyName.contains(":-")) {
-                String[] kv = splitWorker(propertyName, true);
+            if (propertyName.contains(":")) {
+                String[] kv = splitWorker(propertyName, ':', true);
                 propertyName = kv[0];
                 if (kv.length > 1) {
                     defaultValue = kv[1];
@@ -69,7 +69,7 @@ public class SystemPropertyResolver {
             return this;
         }
 
-        private String[] splitWorker(final String str, final boolean preserveAllTokens) {
+        private String[] splitWorker(final String str, final char separator, final boolean preserveAllTokens) {
             // Performance tuned for 2.0 (JDK1.4)
 
             if (str == null) {
@@ -84,14 +84,13 @@ public class SystemPropertyResolver {
             boolean match = false;
             boolean lastMatch = false;
             while (i < len) {
-                if (str.charAt(i) == ':' && (i+1 < len && str.charAt(i+1) == '-')) {
+                if (str.charAt(i) == separator) {
                     if (match || preserveAllTokens) {
                         list.add(str.substring(start, i));
                         match = false;
                         lastMatch = true;
                     }
-                    start = i+2;
-                    i+=2;
+                    start = ++i;
                     continue;
                 }
                 lastMatch = false;

--- a/common/configuration/src/test/java/org/arquillian/pact/configuration/PactRunnerExpressionParserTest.java
+++ b/common/configuration/src/test/java/org/arquillian/pact/configuration/PactRunnerExpressionParserTest.java
@@ -23,7 +23,7 @@ public class PactRunnerExpressionParserTest {
 
     @Test
     public void should_return_default_value_if_no_sys_prop() {
-        assertThat(PactRunnerExpressionParser.parseExpressions("${myprop2:-myvalue}")).isEqualTo("myvalue");
+        assertThat(PactRunnerExpressionParser.parseExpressions("${myprop2:myvalue}")).isEqualTo("myvalue");
     }
 
     @Test
@@ -38,12 +38,12 @@ public class PactRunnerExpressionParserTest {
 
     @Test
     public void can_use_default_chars_if_not_sys_prop() {
-        assertThat(PactRunnerExpressionParser.parseExpressions("myvalue:-secondvalue")).isEqualTo("myvalue:-secondvalue");
+        assertThat(PactRunnerExpressionParser.parseExpressions("myvalue:secondvalue")).isEqualTo("myvalue:secondvalue");
     }
 
     @Test
     public void should_return_empty_string_if_default_value_separator_is_present_but_no_default_value() {
-        assertThat(PactRunnerExpressionParser.parseExpressions("${myprop2:-}")).isEqualTo("");
+        assertThat(PactRunnerExpressionParser.parseExpressions("${myprop2:}")).isEqualTo("");
     }
 
 }

--- a/provider/core/src/main/java/org/arquillian/pact/provider/core/loader/PactFolder.java
+++ b/provider/core/src/main/java/org/arquillian/pact/provider/core/loader/PactFolder.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 
 /**
  * Used to point to source of pacts for contract tests
- * All properties supports ${name:-default} syntax
+ * All properties supports ${name:default} syntax
  *
  * @see PactFolderLoader pact loader
  */

--- a/provider/core/src/main/java/org/arquillian/pact/provider/core/loader/PactUrl.java
+++ b/provider/core/src/main/java/org/arquillian/pact/provider/core/loader/PactUrl.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 
 /**
  * Used to point to source of pacts for contract tests
- * All properties supports ${name:-default} syntax
+ * All properties supports ${name:default} syntax
  *
  * @see PactUrlLoader pact loader
  */

--- a/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGit.java
+++ b/provider/git-loader/src/main/java/org/arquillian/pact/provider/loader/git/PactGit.java
@@ -9,7 +9,7 @@ import java.lang.annotation.Target;
 
 /**
  * Used to point to source of pacts for contract tests from git repository
- * All properties supports ${name:-default} syntax
+ * All properties supports ${name:default} syntax
  *
  * @see PactGitLoader pact loader
  */


### PR DESCRIPTION

#### Short description of what this resolves:

Change default value separator from `:-` to `-`  to align with Arquillian defaults. 

**Fixes**: #40 

